### PR TITLE
Match keywords 'auto', 'dictionary', and handles

### DIFF
--- a/AngelScript.tmLanguage
+++ b/AngelScript.tmLanguage
@@ -185,7 +185,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(enum|void|bool|typedef|funcdef|int|int8|int16|int32|int64|uint|uint8|uint16|uint32|uint64|string|ref|array|double|float)\b</string>
+			<string>\b(enum|void|bool|typedef|funcdef|int|int8|int16|int32|int64|uint|uint8|uint16|uint32|uint64|string|ref|array|double|float|auto|dictionary)\b</string>
+			<key>name</key>
+			<string>storage.type.angelscript</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>[A-Za-z][A-Za-z0-9]+@</string>
 			<key>name</key>
 			<string>storage.type.angelscript</string>
 		</dict>


### PR DESCRIPTION
This adds support for the keywords `auto` and `dictionary` as built-in types.

Also colorize `Type@` as a type. (This is mostly a personal preference and I think it looks a lot better. Will remove it from the pull request if this is unwanted.)
